### PR TITLE
Fix dimensionless unit formatting

### DIFF
--- a/src/earthkit/plots/metadata/units.py
+++ b/src/earthkit/plots/metadata/units.py
@@ -116,7 +116,7 @@ def format_units(units, exponential_notation=False):
     >>> format_units("kg m-2")
     "$kg m^{-2}$"
     """
-    units = earthkit.plots.metadata.units._pintify(units)
+    units = _pintify(units)
     if units.dimensionless:
         return "dimensionless"
     latex_str = f"{units:~L}"

--- a/src/earthkit/plots/metadata/units.py
+++ b/src/earthkit/plots/metadata/units.py
@@ -116,7 +116,10 @@ def format_units(units, exponential_notation=False):
     >>> format_units("kg m-2")
     "$kg m^{-2}$"
     """
-    latex_str = f"{_pintify(units):~L}"
+    units = earthkit.plots.metadata.units._pintify(units)
+    if units.dimensionless:
+        return "dimensionless"
+    latex_str = f"{units:~L}"
     if exponential_notation:
         raise NotImplementedError("Exponential notation is not yet supported.")
     return f"${latex_str}$"


### PR DESCRIPTION
pint, unlike cf-units, collapses dimensionless units. The current formatting then returns a `"$$"` label, which matplotlib cannot handle correctly. The fix checks for dimensionless units explicitly.