### PR TITLE
Change colorbar args

### DIFF
--- a/src/earthkit/plots/styles/legends.py
+++ b/src/earthkit/plots/styles/legends.py
@@ -43,7 +43,7 @@ _DISJOINT_LEGEND_LOCATIONS = {
 }
 
 
-def colorbar(layer, *args, shrink=0.8, aspect=35, ax=None, **kwargs):
+def colorbar(layer, *args, ax=None, **kwargs):
     """
     Produce a colorbar for a given layer.
 
@@ -59,6 +59,8 @@ def colorbar(layer, *args, shrink=0.8, aspect=35, ax=None, **kwargs):
         label = layer.format_string(label)
     except (AttributeError, ValueError, KeyError):
         label = ""
+    shrink: float = kwargs.pop("shrink", 0.8)
+    aspect: int = kwargs.pop("aspect", 35)
 
     kwargs = {**layer.style._legend_kwargs, **kwargs}
     kwargs.setdefault("format", lambda x, _: f"{x:g}")


### PR DESCRIPTION
Currently it is impossible to change shrink and aspect for colorbar through "legend_kwargs" in a style.

If you try it, you get the following error : 

>  File "/home/mprl/bournhonesquej/oper/src/labo/diagnostics/brouillard/visualisation_brouillard.py", line 63, in initialisation_figure
>     fig_map.legend(style=self.style, location="right")
>   File "/home/mprl/bournhonesquej/oper/.venv/lib/python3.11/site-packages/earthkit/plots/schemas.py", line 136, in wrapper
>     return function(*args, **self._update_kwargs(kwargs, keys))
>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>   File "/home/mprl/bournhonesquej/oper/.venv/lib/python3.11/site-packages/earthkit/plots/components/subplots.py", line 882, in legend
>     legend = layer.style.legend(layer, label=kwargs.pop("label", ""), **kwargs)
>              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>   File "/home/mprl/bournhonesquej/oper/.venv/lib/python3.11/site-packages/earthkit/plots/styles/__init__.py", line 649, in legend
>     return method(*args, **kwargs)
>            ^^^^^^^^^^^^^^^^^^^^^^^
>   File "/home/mprl/bournhonesquej/oper/.venv/lib/python3.11/site-packages/earthkit/plots/styles/__init__.py", line 657, in colorbar
>     return styles.legends.colorbar(*args, **kwargs)
>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>   File "/home/mprl/bournhonesquej/oper/.venv/lib/python3.11/site-packages/earthkit/plots/styles/legends.py", line 71, in colorbar
>     cbar = layer.fig.colorbar(
>            ^^^^^^^^^^^^^^^^^^^
> TypeError: matplotlib.figure.FigureBase.colorbar() got multiple values for keyword argument 'shrink'

The goal is to remove shrink and aspect args to be able to change it through the legend_kwargs argument.