### PR TITLE
Adds missing original inputs attrs to NumpySource

### DIFF
--- a/src/earthkit/plots/sources/numpy.py
+++ b/src/earthkit/plots/sources/numpy.py
@@ -34,6 +34,7 @@ class NumpySource(SingleSource):
         v=None,
         crs=None,
         metadata=None,
+        regrid=True,
         **kwargs,
     ):
         self._u = u
@@ -43,6 +44,12 @@ class NumpySource(SingleSource):
         self._metadata.update(kwargs)
         self._earthkit_data = None
         self._gridspec = None
+
+        self._x = x
+        self._y = y
+        self._z = z
+
+        self.regrid = regrid
 
         # Collect only non-None inputs into a dictionary
         inputs = self._collect_inputs(*args, x=x, y=y, z=z)
@@ -214,6 +221,7 @@ class NumpySource(SingleSource):
             from .earthkit import EarthkitSource
 
             m = self._metadata
+
             if self._x is not None and self._y is not None:
                 if "latitudes" not in m and "longitudes" not in m:
                     m["latitudes"] = self._y
@@ -225,6 +233,6 @@ class NumpySource(SingleSource):
                 data = self._data
 
             d = earthkit.data.ArrayField(data, metadata=m)
-            return EarthkitSource(d, regrid=self.regrid)
+            return EarthkitSource(d, regrid=True)
 
         return self

--- a/tests/sources/test_numpy.py
+++ b/tests/sources/test_numpy.py
@@ -160,6 +160,15 @@ def test_NumpySource_all_1d_keywords():
     assert np.array_equal(source.z_values, [7, 8, 9])
 
 
+def test_NumpySource_private_xyz():
+    source = NumpySource(
+        z=[[1, 2, 3], [4, 5, 6]],
+    )
+    assert source._x is None
+    assert source._y is None
+    assert np.array_equal(source._z, [[1, 2, 3], [4, 5, 6]])
+
+
 def test_metadata():
     """Test that metadata is extracted from the data object."""
     source = NumpySource([1, 2, 3], metadata={"key": "value"})


### PR DESCRIPTION
Reintroduces the `_x`, `_y` and `_z` attributes to the `NumpySource`. These attributes contain the _original_ x, y and z inputs, in case we need to do something special with this data and we require the original values (i.e. not the values generates with `_infer_xyz`.

This is particularly important for the `mutate` method, which will convert the source to an `EarthkitSource` when a `gridSpec` is passed in - i.e. when we need to do some interpolation in order to visualise this grid.