### PR TITLE
fix Style comparison

### DIFF
--- a/src/earthkit/plots/styles/__init__.py
+++ b/src/earthkit/plots/styles/__init__.py
@@ -1171,15 +1171,17 @@ _OVERRIDE_KWARGS = ["labels"]
 
 def compare_attributes(self, other, keys):
     def is_equal(x, y):
+        is_x_arr = isinstance(x, np.ndarray)
+        is_y_arr = isinstance(y, np.ndarray)
+
         # Check if both are numpy arrays
-        if isinstance(x, np.ndarray) and isinstance(y, np.ndarray):
+        if is_x_arr and is_y_arr:
             return np.array_equal(x, y)
         # If one is an array and the other isn't, they are not equal
-        elif isinstance(x, np.ndarray) or isinstance(y, np.ndarray):
+        if is_x_arr != is_y_arr:
             return False
         # Default to standard equality check for non-array types
-        else:
-            return x == y
+        return x == y
 
     # Use the is_equal function for each key in your check
     try:

--- a/src/earthkit/plots/styles/levels.py
+++ b/src/earthkit/plots/styles/levels.py
@@ -192,9 +192,14 @@ class Levels:
 
     def __eq__(self, other):
         if self._levels is not None and other is not None:
+            is_self_arr = isinstance(self._levels, np.ndarray)
+            is_other_arr = isinstance(other._levels, np.ndarray)
+            if is_self_arr and is_other_arr:
+                return np.array_equal(self._levels, other._levels)
+            if is_self_arr != is_other_arr:
+                return False
             return self._levels == other._levels
-        else:
-            return False
+        return False
 
     def __init__(
         self,


### PR DESCRIPTION
When comparing different styles from different subplots, the levels were not comparing correctly if they were `np.ndarray`. The `__eq__()` of the class `Levels` returned an array of bool when using this style:
```
style = Style(levels=np.arange(0, 10, 0.5))
charts = fig.subplots
for i, chart in enumerate(charts):
    chart.coastlines()
    chart.borders()
    chart.pcolormesh(z=da, style=style)
```