### PR TITLE
Fixes bugs with extracting data and geometries

### DIFF
--- a/src/earthkit/plots/components/maps.py
+++ b/src/earthkit/plots/components/maps.py
@@ -368,16 +368,18 @@ class Map(Subplot):
 
                 reprojected_geometries = []
                 for record in filtered_records:
-                    projected_geom = reproject_geom(record.geometry)
+                    projected_geom = record.geometry
 
                     # **Clip to viewport**
-                    clipped_geom = projected_geom.intersection(extent_box)
+                    clipped_geom = projected_geom
 
                     if not clipped_geom.is_empty:  # Only keep visible parts
                         reprojected_geometries.append(clipped_geom)
 
                 # Add optimized features
-                feature = cfeature.ShapelyFeature(reprojected_geometries, self.crs)
+                feature = cfeature.ShapelyFeature(
+                    reprojected_geometries, ccrs.PlateCarree()
+                )
                 result = self.ax.add_feature(feature, *args, **kwargs)
 
                 if special_styles is not None:

--- a/src/earthkit/plots/components/maps.py
+++ b/src/earthkit/plots/components/maps.py
@@ -16,9 +16,6 @@ import cartopy.crs as ccrs
 import cartopy.feature as cfeature
 import cartopy.io.shapereader as shpreader
 import matplotlib.patheffects as pe
-from pyproj import Transformer
-from shapely.geometry import box
-from shapely.ops import transform
 
 from earthkit.plots.components.subplots import Subplot
 from earthkit.plots.geo import coordinate_reference_systems, domains, natural_earth
@@ -354,41 +351,22 @@ class Map(Subplot):
                         adjust_labels=adjust_labels,
                     )
 
-                # **Optimized Geometry Reprojection & Clipping**
-                transformer = Transformer.from_crs(
-                    "EPSG:4326", self.crs, always_xy=True
-                )
-
-                def reproject_geom(geom):
-                    return transform(transformer.transform, geom)
-
-                # Get visible extent of the plot
-                xlim, ylim = self.ax.get_xlim(), self.ax.get_ylim()
-                extent_box = box(xlim[0], ylim[0], xlim[1], ylim[1])
-
-                reprojected_geometries = []
+                geometries = []
                 for record in filtered_records:
-                    projected_geom = record.geometry
+                    geom = record.geometry
 
-                    # **Clip to viewport**
-                    clipped_geom = projected_geom
-
-                    if not clipped_geom.is_empty:  # Only keep visible parts
-                        reprojected_geometries.append(clipped_geom)
+                    if not geom.is_empty:  # Only keep visible parts
+                        geometries.append(geom)
 
                 # Add optimized features
-                feature = cfeature.ShapelyFeature(
-                    reprojected_geometries, ccrs.PlateCarree()
-                )
+                feature = cfeature.ShapelyFeature(geometries, ccrs.PlateCarree())
                 result = self.ax.add_feature(feature, *args, **kwargs)
 
                 if special_styles is not None:
                     for record, style in special_records:
-                        projected_geom = reproject_geom(record.geometry)
-                        clipped_geom = projected_geom.intersection(extent_box)
-
-                        if not clipped_geom.is_empty:
-                            feature = cfeature.ShapelyFeature([clipped_geom], self.crs)
+                        geom = record.geometry
+                        if not geom.is_empty:
+                            feature = cfeature.ShapelyFeature([geom], self.crs)
                             self.ax.add_feature(feature, *args, **{**kwargs, **style})
 
                 return result

--- a/src/earthkit/plots/geo/domains.py
+++ b/src/earthkit/plots/geo/domains.py
@@ -40,14 +40,16 @@ NO_BBOX = [
 
 def force_minus_180_to_180(x):
     """
-    Force an array of longitudes to be in the range -180 to 180.
-
-    Parameters
-    ----------
-    x : array-like
-        The longitudes to be forced into the range -180 to 180.
+    Force an array of longitudes to lie in [-180, +180],
+    *but* preserve any original +180° values (so you don’t
+    collapse the east edge onto the west edge).
     """
-    return (x + 180) % 360 - 180
+    x = np.asarray(x)
+    x2 = (x + 180) % 360 - 180
+    # now restore +180 wherever the original was exactly +180
+    # (so that our grid retains its full span)
+    x2 = np.where(np.isclose(x, 180), 180, x2)
+    return x2
 
 
 def roll_from_0_360_to_minus_180_180(x):
@@ -102,7 +104,9 @@ def force_0_to_360(x):
     x : array-like
         The longitudes to be forced into the range 0 to 360.
     """
-    return x % 360
+    x2 = np.asarray(x % 360)
+    x2 = np.where(np.isclose(x, 360), 360, x2)
+    return x2
 
 
 def is_latlon(data):

--- a/tests/geo/test_domains.py
+++ b/tests/geo/test_domains.py
@@ -29,6 +29,23 @@ def test_union():
     )
 
 
+def test_force_minus_180_to_180():
+    assert domains.force_minus_180_to_180(-190) == 170
+    assert domains.force_minus_180_to_180(190) == -170
+    assert domains.force_minus_180_to_180(180) == 180
+    assert domains.force_minus_180_to_180(-180) == -180
+    assert domains.force_minus_180_to_180(0) == 0
+
+
+def test_force_0_to_360():
+    assert domains.force_0_to_360(-10) == 350
+    assert domains.force_0_to_360(370) == 10
+    assert domains.force_0_to_360(360) == 360
+    assert domains.force_0_to_360(0) == 0
+    assert domains.force_0_to_360(180) == 180
+    assert domains.force_0_to_360(-180) == 180
+
+
 def test_Domain_from_string():
     domain = domains.Domain.from_string("United Kingdom")
     assert list(domain.bbox) == pytest.approx([-363797, 373425, -541558, 545791], 0.001)


### PR DESCRIPTION
This PR reverts the on-the-fly geometry clipping logic for coastlines, borders, and other shapefiles (issues #75 & #76) and restores full-shapefile plotting to ensure visual correctness. It also fixes a longitude-wrapping bug when extracting data domains that start and end on the same longitude.

**Changes**
- Instead of attempting to clip shapefile geometries to the current view for performance, we now plot the entire shapefile. This eliminates spurious horizontal lines and artifacts in certain projections, as discussed in #76, but significantly reduces performance.
- When a map's domain wraps around (e.g. –180→+180 or 0→360), exact endpoint values were collapsed (180→–180, 360→0), resulting in tiny slivers instead of the full globe. We now preserve any original +180° or +360° endpoints when re-wrapping longitudes.

**Future Work**
We should revisit and optimise geometry-clipping with a more robust spatial-indexing approach to regain performance without graphical artifacts, but for now, it's better to have visually correct geometries.
 