### PR TITLE
92 memory problem in version 030

### DIFF
--- a/src/earthkit/plots/geo/domains.py
+++ b/src/earthkit/plots/geo/domains.py
@@ -458,8 +458,6 @@ class Domain:
                         extra_values = [v[mask] for v in extra_values]
 
                 else:
-                    from datetime import datetime
-                    start = datetime.now()
                     # Calculate grid resolution
                     resolution_x = (x.max() - x.min()) / x.shape[1]
                     resolution_y = (y.max() - y.min()) / y.shape[0]
@@ -595,8 +593,7 @@ class Domain:
                                         v[bbox_fallback].reshape(shape)
                                         for v in extra_values
                                     ]
-                    end = datetime.now()
-                    print(f"Time taken: {end - start}")
+
         if not extra_values:
             return x, y, values
         else:

--- a/src/earthkit/plots/geo/domains.py
+++ b/src/earthkit/plots/geo/domains.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import warnings
 
 import cartopy.crs as ccrs
 import numpy as np
@@ -459,55 +458,145 @@ class Domain:
                         extra_values = [v[mask] for v in extra_values]
 
                 else:
-                    # Gridded data: use bounding box slicing
-                    try:
-                        import scipy.ndimage as sn
-                    except ImportError:
-                        warnings.warn(
-                            "No scipy installation found; scipy is required to "
-                            "speed up plotting of smaller domains by slicing "
-                            "the input data. Consider installing scipy to speed "
-                            "up this process."
-                        )
-                    finally:
-                        bbox = np.where(
-                            (x >= crs_bounds[0])
-                            & (x <= crs_bounds[1])
-                            & (y >= crs_bounds[2])
-                            & (y <= crs_bounds[3]),
-                            True,
-                            False,
-                        )
+                    from datetime import datetime
+                    start = datetime.now()
+                    # Calculate grid resolution
+                    resolution_x = (x.max() - x.min()) / x.shape[1]
+                    resolution_y = (y.max() - y.min()) / y.shape[0]
 
-                        # Calculate grid resolution
-                        resolution_x = (x.max() - x.min()) / x.shape[1]
-                        resolution_y = (y.max() - y.min()) / y.shape[0]
-                        resolution = max(resolution_x, resolution_y)
+                    # Calculate padding (roughly 1 degree's worth)
+                    padding_cells = max(1, int(1 / max(resolution_x, resolution_y)))
 
-                        # Calculate kernel size as roughly 2 / resolution in degrees
-                        kernel_size = max(1, int(2 / resolution))
-                        kernel = np.ones((kernel_size, kernel_size), dtype="uint8")
-                        bbox = sn.morphology.binary_dilation(
-                            bbox,
-                            kernel,
-                        ).astype(bool)
+                    # Check if we need to handle longitude wrapping
+                    x_min = x.min()
+                    x_max = x.max()
 
+                    # Case 1: Data is 0-360, domain spans negative longitudes (e.g., Europe domain)
+                    if x_min >= 0 and x_max <= 360 and crs_bounds[0] < 0:
+                        # Roll data so that negative longitudes are at the end
+                        roll_amount = int((360 - abs(crs_bounds[0])) / resolution_x)
+                        # Ensure roll_amount is within reasonable bounds
+                        roll_amount = max(0, min(roll_amount, x.shape[1] - 1))
+
+                        x = np.roll(x, roll_amount, axis=1)
+                        y = np.roll(y, roll_amount, axis=1)
+                        if values is not None:
+                            values = np.roll(values, roll_amount, axis=1)
+                        if extra_values is not None:
+                            extra_values = [
+                                np.roll(v, roll_amount, axis=1) for v in extra_values
+                            ]
+
+                        # Adjust bounds to match rolled coordinates
+                        adjusted_bounds = [
+                            crs_bounds[0]
+                            + 360,  # Shift negative longitudes to positive
+                            crs_bounds[1],
+                            crs_bounds[2],
+                            crs_bounds[3],
+                        ]
+                    # Case 2: Data is -180 to 180, domain spans 0 meridian
+                    elif (
+                        x_min < 0
+                        and x_max > 0
+                        and crs_bounds[0] < 0
+                        and crs_bounds[1] > 0
+                    ):
+                        # Roll data so that the domain is continuous
+                        roll_amount = int((180 - crs_bounds[0]) / resolution_x)
+                        # Ensure roll_amount is within reasonable bounds
+                        roll_amount = max(0, min(roll_amount, x.shape[1] - 1))
+
+                        x = np.roll(x, roll_amount, axis=1)
+                        y = np.roll(y, roll_amount, axis=1)
+                        if values is not None:
+                            values = np.roll(values, roll_amount, axis=1)
+                        if extra_values is not None:
+                            extra_values = [
+                                np.roll(v, roll_amount, axis=1) for v in extra_values
+                            ]
+
+                        adjusted_bounds = crs_bounds
+                    else:
+                        adjusted_bounds = crs_bounds
+
+                    # Apply padding to the adjusted bounds
+                    padded_bounds = [
+                        adjusted_bounds[0] - padding_cells * resolution_x,
+                        adjusted_bounds[1] + padding_cells * resolution_x,
+                        adjusted_bounds[2] - padding_cells * resolution_y,
+                        adjusted_bounds[3] + padding_cells * resolution_y,
+                    ]
+
+                    # Use boolean masking instead of searchsorted for more robust handling
+                    bbox = np.where(
+                        (x >= padded_bounds[0])
+                        & (x <= padded_bounds[1])
+                        & (y >= padded_bounds[2])
+                        & (y <= padded_bounds[3]),
+                        True,
+                        False,
+                    )
+
+                    if bbox.any():
+                        # Get the shape of the valid region
                         shape = bbox[
                             np.ix_(np.any(bbox, axis=1), np.any(bbox, axis=0))
                         ].shape
 
-                        x = x[bbox].reshape(shape)
-                        y = y[bbox].reshape(shape)
-                        if values is not None:
-                            if additional_dim is not None:
-                                values = values[bbox].reshape(shape + (additional_dim,))
-                            else:
-                                values = values[bbox].reshape(shape)
-                        if extra_values is not None:
-                            extra_values = [
-                                v[bbox].reshape(shape) for v in extra_values
-                            ]
+                        if shape[0] > 0 and shape[1] > 0:
+                            x = x[bbox].reshape(shape)
+                            y = y[bbox].reshape(shape)
+                            if values is not None:
+                                if additional_dim is not None:
+                                    values = values[bbox].reshape(
+                                        shape + (additional_dim,)
+                                    )
+                                else:
+                                    values = values[bbox].reshape(shape)
+                            if extra_values is not None:
+                                extra_values = [
+                                    v[bbox].reshape(shape) for v in extra_values
+                                ]
+                        else:
+                            # Fallback: use original data if reshaping results in empty arrays
+                            pass
+                    else:
+                        # Fallback: if no data found with padding, try without padding
+                        bbox_fallback = np.where(
+                            (x >= adjusted_bounds[0])
+                            & (x <= adjusted_bounds[1])
+                            & (y >= adjusted_bounds[2])
+                            & (y <= adjusted_bounds[3]),
+                            True,
+                            False,
+                        )
 
+                        if bbox_fallback.any():
+                            shape = bbox_fallback[
+                                np.ix_(
+                                    np.any(bbox_fallback, axis=1),
+                                    np.any(bbox_fallback, axis=0),
+                                )
+                            ].shape
+
+                            if shape[0] > 0 and shape[1] > 0:
+                                x = x[bbox_fallback].reshape(shape)
+                                y = y[bbox_fallback].reshape(shape)
+                                if values is not None:
+                                    if additional_dim is not None:
+                                        values = values[bbox_fallback].reshape(
+                                            shape + (additional_dim,)
+                                        )
+                                    else:
+                                        values = values[bbox_fallback].reshape(shape)
+                                if extra_values is not None:
+                                    extra_values = [
+                                        v[bbox_fallback].reshape(shape)
+                                        for v in extra_values
+                                    ]
+                    end = datetime.now()
+                    print(f"Time taken: {end - start}")
         if not extra_values:
             return x, y, values
         else:

--- a/tests/geo/test_domains.py
+++ b/tests/geo/test_domains.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import cartopy.crs as ccrs
+import numpy as np
 import pytest
 
 from earthkit.plots.geo import domains
@@ -79,3 +81,163 @@ def test_Domain_title_without_name():
 def test_Domain_title_without_name_zero():
     domain = domains.Domain([-180, 180, 0, 90])
     assert domain.title == "-180°W, 180°E, 0°, 90°N"
+
+
+class TestDomainExtract:
+    """Test cases for the Domain.extract method."""
+
+    def test_extract_simple_gridded_data(self):
+        """Test basic extraction of gridded data without longitude wrapping."""
+        domain = domains.Domain([-10, 10, -10, 10])
+
+        x = np.linspace(-20, 20, 41)
+        y = np.linspace(-20, 20, 41)
+        values = np.random.random((41, 41))
+
+        x_ext, y_ext, values_ext = domain.extract(x, y, values)
+
+        assert x_ext.min() >= -11  # Domain -10 with ~1 degree padding
+        assert x_ext.max() <= 11
+        assert y_ext.min() >= -11
+        assert y_ext.max() <= 11
+
+        assert values_ext.shape == x_ext.shape == y_ext.shape
+
+    def test_extract_longitude_wrapping_0_360_to_negative(self):
+        """Test longitude wrapping when data is 0-360 and domain spans negative longitudes."""
+        domain = domains.Domain([-10, 40, 35, 70])  # Europe-like domain
+
+        x = np.linspace(0, 360, 361)
+        y = np.linspace(-90, 90, 181)
+        values = np.random.random((181, 361))
+
+        x_ext, y_ext, values_ext = domain.extract(x, y, values)
+
+        assert x_ext.shape == y_ext.shape == values_ext.shape
+        assert x_ext.shape[0] > 0
+        assert x_ext.shape[1] > 0
+
+    def test_extract_longitude_wrapping_minus_180_180_spanning_0(self):
+        """Test longitude wrapping when data is -180 to 180 and domain spans 0 meridian."""
+        domain = domains.Domain([-5, 5, -5, 5])
+
+        x = np.linspace(-180, 180, 361)
+        y = np.linspace(-90, 90, 181)
+        values = np.random.random((181, 361))
+
+        x_ext, y_ext, values_ext = domain.extract(x, y, values)
+
+        assert x_ext.shape == y_ext.shape == values_ext.shape
+        assert x_ext.shape[0] > 0
+        assert x_ext.shape[1] > 0
+
+    def test_extract_with_extra_values(self):
+        """Test extraction with extra values."""
+        domain = domains.Domain([-5, 5, -5, 5])
+
+        x = np.linspace(-10, 10, 21)
+        y = np.linspace(-10, 10, 21)
+        values = np.random.random((21, 21))
+        extra1 = np.random.random((21, 21))
+        extra2 = np.random.random((21, 21))
+
+        x_ext, y_ext, values_ext, extra_ext = domain.extract(
+            x, y, values, [extra1, extra2]
+        )
+
+        assert x_ext.shape == y_ext.shape == values_ext.shape
+        assert len(extra_ext) == 2
+        assert extra_ext[0].shape == x_ext.shape
+        assert extra_ext[1].shape == x_ext.shape
+
+    def test_extract_with_3d_values(self):
+        """Test extraction with 3D values (e.g., time series)."""
+        domain = domains.Domain([-5, 5, -5, 5])
+
+        x = np.linspace(-10, 10, 21)
+        y = np.linspace(-10, 10, 21)
+        values = np.random.random((21, 21, 5))  # 5 time steps
+
+        x_ext, y_ext, values_ext = domain.extract(x, y, values)
+
+        assert values_ext.shape == (x_ext.shape[0], x_ext.shape[1], 5)
+
+    def test_extract_basic_functionality(self):
+        """Test basic extraction functionality with various data types."""
+        domain = domains.Domain([-5, 5, -5, 5])
+
+        test_cases = [
+            # (x_shape, y_shape, values_shape, description)
+            ((21, 21), (21, 21), (21, 21), "2D gridded data"),
+            ((21, 21), (21, 21), (21, 21, 3), "2D gridded data with 3D values"),
+            ((21,), (21,), (21, 21), "1D coordinates that get converted to meshgrid"),
+        ]
+
+        for x_shape, y_shape, values_shape, description in test_cases:
+            if len(x_shape) == 1:
+                x = np.linspace(-10, 10, x_shape[0])
+                y = np.linspace(-10, 10, y_shape[0])
+            else:
+                x = np.random.random(x_shape)
+                y = np.random.random(y_shape)
+
+            values = np.random.random(values_shape)
+
+            x_ext, y_ext, values_ext = domain.extract(x, y, values)
+
+            assert x_ext.size > 0, f"Failed for {description}"
+            assert y_ext.size > 0, f"Failed for {description}"
+            assert values_ext.size > 0, f"Failed for {description}"
+
+            assert x_ext.shape == y_ext.shape, f"Shape mismatch for {description}"
+            if values_ext.ndim == 2:
+                assert (
+                    values_ext.shape == x_ext.shape
+                ), f"Values shape mismatch for {description}"
+            elif values_ext.ndim == 3:
+                assert (
+                    values_ext.shape[:2] == x_ext.shape
+                ), f"Values shape mismatch for {description}"
+
+    def test_extract_edge_case_empty_result(self):
+        """Test extraction edge case where result would be empty."""
+        domain = domains.Domain([0.1, 0.2, 0.1, 0.2])
+
+        x = np.linspace(-1, 1, 21)
+        y = np.linspace(-1, 1, 21)
+        values = np.random.random((21, 21))
+
+        x_ext, y_ext, values_ext = domain.extract(x, y, values)
+
+        assert x_ext.size > 0
+        assert y_ext.size > 0
+        assert values_ext.size > 0
+
+    def test_extract_with_source_crs(self):
+        """Test extraction with different source CRS."""
+        domain = domains.Domain([-5, 5, -5, 5], crs=ccrs.LambertAzimuthalEqualArea())
+
+        x = np.linspace(-10, 10, 21)
+        y = np.linspace(-10, 10, 21)
+        values = np.random.random((21, 21))
+
+        x_ext, y_ext, values_ext = domain.extract(
+            x, y, values, source_crs=ccrs.PlateCarree()
+        )
+
+        assert x_ext.shape == y_ext.shape == values_ext.shape
+        assert x_ext.size > 0
+
+    def test_extract_1d_coordinates(self):
+        """Test extraction with 1D coordinates that get converted to meshgrid."""
+        domain = domains.Domain([-5, 5, -5, 5])
+
+        x = np.linspace(-10, 10, 21)
+        y = np.linspace(-10, 10, 21)
+        values = np.random.random((21, 21))
+
+        x_ext, y_ext, values_ext = domain.extract(x, y, values)
+
+        assert x_ext.shape == y_ext.shape == values_ext.shape
+        assert x_ext.ndim == 2  # Should be converted to 2D
+        assert y_ext.ndim == 2


### PR DESCRIPTION
### Description

This PR improves the performance and reliability of bounding box extraction in earthkit-plots.
- Removed the previous (expensive) SciPy binary dilation-based padding approach and switched to lightweight NumPy padding.
- Eliminates excessive memory consumption, preventing MemoryErrors when working with high-resolution datasets (see #92).
- Area extraction is now several orders of magnitude faster. For example, cutting out 1 km resolution data over Switzerland improved from ~8 s → ~0.01 s in testing.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 