### PR TITLE
Remove auto tricontour over-rides

### DIFF
--- a/src/earthkit/plots/interactive/inputs.py
+++ b/src/earthkit/plots/interactive/inputs.py
@@ -19,9 +19,6 @@ import numpy as np
 
 from earthkit.plots.interactive import times
 
-# from earthkit.plots.schemas import schema
-
-
 AXES = ["x", "y"]
 
 


### PR DESCRIPTION
### Description

I would like to go through the full implications of this. With some reduced gaussian grid examples, the code I remove was blocking my attempts to use the earthkit-plots interpolation features. In the example I had, ek-plots interpolation is faster tricontour, and includes additional features.

Maybe the auto-switching to tricontour could be kept, but should be done in a slightly more selective way?


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 