### PR TITLE
feat: Add unit aliases

### DIFF
--- a/src/earthkit/plots/metadata/units.py
+++ b/src/earthkit/plots/metadata/units.py
@@ -80,9 +80,15 @@ def format_unit_simple(unit, registry, **options):
     return latex_string
 
 
+UNIT_STR_ALIASES = {"(0 - 1)": "fraction"}
+
+
 def _pintify(unit_str):
     if unit_str is None:
         unit_str = "dimensionless"
+
+    if unit_str in UNIT_STR_ALIASES:
+        unit_str = UNIT_STR_ALIASES[unit_str]
 
     # Replace spaces with dots
     unit_str = unit_str.replace(" ", ".")


### PR DESCRIPTION
### Description
Some grib units are a bit odd, particuarly `(0-1)` which can be intepreted as a fraction.

Add aliases to deal with this.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 