### PR TITLE
feat: Vector identification in quickplot

### DIFF
--- a/src/earthkit/plots/components/subplots.py
+++ b/src/earthkit/plots/components/subplots.py
@@ -29,6 +29,7 @@ from earthkit.plots.metadata.formatters import (
 from earthkit.plots.resample import Interpolate, Regrid
 from earthkit.plots.schemas import schema
 from earthkit.plots.sources import get_source, get_vector_sources
+from earthkit.plots.sources.multi import MultiSource
 from earthkit.plots.sources.numpy import NumpySource
 from earthkit.plots.styles import _STYLE_KWARGS, Contour, Quiver, Style, auto
 from earthkit.plots.utils import string_utils
@@ -291,10 +292,14 @@ class Subplot:
                 colors=False,
                 style=None,
                 units=None,
+                auto_style=False,
                 source_units=None,
                 resample=Regrid(40),
                 **kwargs,
             ):
+                u_source = None
+                v_source = None
+
                 if not args:
                     u_source = get_source(u, x=x, y=y, units=source_units)
                     v_source = get_source(v, x=x, y=y, units=source_units)
@@ -306,14 +311,20 @@ class Subplot:
                     u_source = get_source(args[0], x=x, y=y, units=source_units)
                     v_source = get_source(args[1], x=x, y=y, units=source_units)
 
+                assert (
+                    u_source is not None and v_source is not None
+                ), "Could not determine vector components from input arguments"
+
                 kwargs = {**self._plot_kwargs(u_source), **kwargs}
+
+                multi_source = MultiSource([u_source, v_source])
 
                 style = self._configure_style(
                     method_name or method.__name__,
                     style,
-                    u_source,
+                    multi_source,
                     units,
-                    False,
+                    auto_style,
                     kwargs,
                 )
                 m = getattr(style, method_name or method.__name__)

--- a/src/earthkit/plots/quickplot.py
+++ b/src/earthkit/plots/quickplot.py
@@ -20,6 +20,7 @@ from earthkit.data.core import Base
 
 from earthkit.plots.components import layouts
 from earthkit.plots.components.figures import Figure
+from earthkit.plots.identifiers import group_vectors
 from earthkit.plots.schemas import schema
 from earthkit.plots.utils import iter_utils
 
@@ -35,6 +36,7 @@ def quickplot(
     groupby=None,
     units=None,
     subplot_titles=None,
+    combine_vectors=True,
     **kwargs,
 ):
     """
@@ -59,6 +61,8 @@ def quickplot(
         Dimension along which to group the data.
     units : string or list, optional
         Units to convert the data to.
+    combine_vectors : bool, optional
+        Whether to combine vector components (u, v), and use vector based plotting, i.e. `quiver`.
     **kwargs : dict
         Additional arguments for the plot method(s).
 
@@ -107,7 +111,13 @@ def quickplot(
     for i, (group_val, group_args) in enumerate(grouped_data.items()):
         subplot = figure.add_map(domain=domain, crs=crs)
 
+        if combine_vectors:
+            group_args = group_vectors(group_args)
+
         if isinstance(group_args, FieldList):
+            group_args = list(group_args)
+
+        if isinstance(group_args, (list, tuple)):
             for j, (arg, method) in enumerate(zip(group_args, methods)):
                 unit = units[j]
                 try:

--- a/src/earthkit/plots/sources/__init__.py
+++ b/src/earthkit/plots/sources/__init__.py
@@ -15,6 +15,7 @@
 import earthkit.data as ek_data
 
 from earthkit.plots.sources.earthkit import EarthkitSource
+from earthkit.plots.sources.multi import MultiSource
 from earthkit.plots.sources.numpy import NumpySource
 from earthkit.plots.sources.xarray import XarraySource
 
@@ -79,6 +80,8 @@ def _get_source_class(*args, data):
             cls = XarraySource
         elif isinstance(core_data, ek_data.core.Base):
             cls = EarthkitSource
+        elif isinstance(core_data, (list, tuple)):
+            cls = MultiSource
     return cls
 
 

--- a/src/earthkit/plots/sources/earthkit.py
+++ b/src/earthkit/plots/sources/earthkit.py
@@ -92,11 +92,17 @@ class EarthkitSource(SingleSource):
 
             x_values, y_values = get_points(schema.interpolate_target_resolution)
 
-            z_values = earthkit.regrid.interpolate(
-                z_values,
-                self.gridspec.to_dict(),
-                {"grid": [schema.interpolate_target_resolution] * 2},
-            )
+            def interpolate(v):
+                return earthkit.regrid.interpolate(
+                    v,
+                    self.gridspec.to_dict(),
+                    {"grid": [schema.interpolate_target_resolution] * 2},
+                )
+
+            if z_values.ndim == 2:  # In case of FieldList
+                z_values = np.array([interpolate(z) for z in z_values])
+            else:
+                z_values = interpolate(z_values)
         else:
             x_values = self._extract_coord_values(self._x, axis="x")
             y_values = self._extract_coord_values(self._y, axis="y")

--- a/src/earthkit/plots/sources/multi.py
+++ b/src/earthkit/plots/sources/multi.py
@@ -17,8 +17,7 @@ from functools import cached_property
 import earthkit.data
 import numpy as np
 
-from earthkit.plots.sources.earthkit import EarthkitSource
-from earthkit.plots.sources.numpy import NumpySource
+from earthkit.plots.sources.single import SingleSource
 
 
 class MultiSource:
@@ -32,33 +31,52 @@ class MultiSource:
             self._data = earthkit.data.from_object(self._data)
         return self._data
 
+    @property
     def x_values(self):
         return [source.x_values for source in self]
 
+    @property
     def y_values(self):
         return [source.y_values for source in self]
 
+    @property
     def z_values(self):
         return [source.z_values for source in self]
 
+    @property
     def crs(self):
         return [source.crs for source in self]
 
     def metadata(self, key, default=None):
-        return [source.metadata(key, default) for source in self]
+        return list(set([source.metadata(key, default) for source in self]))
 
+    @property
     def u_values(self):
         return [source.u_values for source in self]
 
+    @property
     def v_values(self):
         return [source.v_values for source in self]
 
+    @property
+    def units(self):
+        """Returns the units of the data, if specified in metadata."""
+        result = self.metadata("units")
+        if isinstance(result, list):
+            result = result[0]
+        return result
+
     def __iter__(self):
-        if isinstance(self.data, (list, np.ndarray)):
-            yield NumpySource(self.data, **self._kwargs)
-        else:
-            for field in self.data:
-                yield EarthkitSource(field, **self._kwargs)
+        for i in range(len(self)):
+            yield self[i]
+
+    def __len__(self):
+        return len(self.data)
 
     def __getitem__(self, index):
-        return EarthkitSource(self.data[index], **self._kwargs)
+        from earthkit.plots.sources import get_source
+
+        d = self.data[index]
+        if isinstance(d, SingleSource):
+            return d
+        return get_source(d, **self._kwargs)

--- a/src/earthkit/plots/styles/__init__.py
+++ b/src/earthkit/plots/styles/__init__.py
@@ -946,11 +946,29 @@ class Categorical(Style):
 
 
 class Quiver(Style):
-    """A style for plotting vector data."""
+    """A style for plotting vector data.
 
-    def __init__(self, *args, colors=None, **kwargs):
+    Parameters
+    ----------
+    colors : str or list or matplotlib.colors.Colormap, optional
+        The colors to be used in this `Style`. This can be a named matplotlib
+        colormap, a list of colors (as named CSS4 colors, hexadecimal colors or
+        three (four)-element lists of RGB(A) values), or a pre-defined
+        matplotlib colormap object. If not provided, the default colormap of the
+        active `schema` will be used.
+    preferred_method : str, optional
+        The preferred method for plotting the data. Must be one of `quiver` or
+        `barbs`.
+    **kwargs
+        Additional keyword arguments to be passed to the `quiver`, `barbs` or
+        `vector` method.
+    """
+
+    def __init__(self, *args, colors=None, preferred_method="quiver", **kwargs):
         kwargs["legend_style"] = "vector"
-        super().__init__(*args, colors=colors, **kwargs)
+        super().__init__(
+            *args, colors=colors, preferred_method=preferred_method, **kwargs
+        )
 
 
 class Contour(Style):


### PR DESCRIPTION
### Description

Improve quickplot such that vectors can be automatically identified, and plotted as a quiver or other vector type.

Adds a `combine_vectors` argument to quickplot for control

Closes #79 

### Example
```python

import earthkit as ek
ds = ek.data.from_source("mars", {'levtype':'sfc', 'param':['msl', '2t', '10u','10v'], 'date':-1})
fig = ek.plots.quickplot(ds, domain="Europe", combine_vectors=True, groupby='step')
```
<img width="668" height="715" alt="image" src="https://github.com/user-attachments/assets/2314f0c4-fe49-4d26-abe4-d0eb4f7bb9fa" />

### Dependencies
Builds on: #108 
Requires: https://github.com/ecmwf/earthkit-plots-default-styles/pull/5

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 