### PR TITLE
Fixes a bug which messed up contour lines when suptitle was called

### DIFF
--- a/src/earthkit/plots/components/figures.py
+++ b/src/earthkit/plots/components/figures.py
@@ -593,7 +593,7 @@ class Figure:
                 title_fontsize = first_ax.title.get_fontsize()
         except IndexError:
             # IndexError: self.fig.axes is empty
-            # NOTE: We are unlikely to get here, but it's good to be defensive.
+            pass
 
         # Convert font size to figure-relative units using actual figure DPI
         fig_dpi = self.fig.get_dpi()

--- a/src/earthkit/plots/components/figures.py
+++ b/src/earthkit/plots/components/figures.py
@@ -560,7 +560,6 @@ class Figure:
             y = self._get_suptitle_y()
 
         result = self.fig.suptitle(label, y=y, **kwargs)
-        # self.draw()
         return result
 
     def draw(self):

--- a/src/earthkit/plots/components/figures.py
+++ b/src/earthkit/plots/components/figures.py
@@ -585,18 +585,15 @@ class Figure:
         fig_height = self.fig.get_size_inches()[1]
 
         # Get the default title font size (or use a reasonable default)
-        default_title_fontsize = 12
+        title_fontsize = 12
         try:
             # Try to get font size from the first subplot's title
             first_ax = self.fig.axes[0]
             if first_ax.get_title():
                 title_fontsize = first_ax.title.get_fontsize()
-            else:
-                title_fontsize = default_title_fontsize
         except IndexError:
             # IndexError: self.fig.axes is empty
             # NOTE: We are unlikely to get here, but it's good to be defensive.
-            title_fontsize = default_title_fontsize
 
         # Convert font size to figure-relative units using actual figure DPI
         fig_dpi = self.fig.get_dpi()

--- a/src/earthkit/plots/components/figures.py
+++ b/src/earthkit/plots/components/figures.py
@@ -585,18 +585,23 @@ class Figure:
         fig_height = self.fig.get_size_inches()[1]
 
         # Get the default title font size (or use a reasonable default)
+        default_title_fontsize = 12
         try:
             # Try to get font size from the first subplot's title
             first_ax = self.fig.axes[0]
             if first_ax.get_title():
                 title_fontsize = first_ax.title.get_fontsize()
             else:
-                title_fontsize = 12
-        except AttributeError:
-            title_fontsize = 12
+                title_fontsize = default_title_fontsize
+        except (IndexError, TypeError):
+            # IndexError: self.fig.axes is empty
+            # TypeError: self.fig.axes[0] is not a valid Axes object
+            # NOTE: We are unlikely to get here, but it's good to be defensive.
+            title_fontsize = default_title_fontsize
 
-        # Convert font size to figure-relative units
-        title_height_fig = (title_fontsize / 72.0) / fig_height
+        # Convert font size to figure-relative units using actual figure DPI
+        fig_dpi = self.fig.get_dpi()
+        title_height_fig = (title_fontsize / fig_dpi) / fig_height
 
         # Add some padding above the title
         title_padding = 0.15  # 15% of figure height

--- a/src/earthkit/plots/components/figures.py
+++ b/src/earthkit/plots/components/figures.py
@@ -560,7 +560,7 @@ class Figure:
             y = self._get_suptitle_y()
 
         result = self.fig.suptitle(label, y=y, **kwargs)
-        self.draw()
+        # self.draw()
         return result
 
     def draw(self):
@@ -573,47 +573,38 @@ class Figure:
                 layer.reset_facecolors()
 
     def _get_suptitle_y(self):
-        self.draw()
-        max_title_top = 0
-        renderer = self.fig.canvas.get_renderer()
-        inv_transform = self.fig.transFigure.inverted()
+        """
+        Calculate suptitle y position  by using the axis positions and estimated
+        title heights.
+        """
+        if not self.subplots:
+            return 0.95  # Default fallback
 
-        for ax in self.fig.axes:
-            # Check if the subplot has a title
-            title = ax.get_title()
+        # Find the highest subplot position
+        max_ax_top = max(ax.get_position().y1 for ax in self.fig.axes)
 
-            if title:  # If there is a title, we need to handle the title object itself
-                title_obj = ax.title
-                title_bbox = title_obj.get_window_extent(renderer)
-                # Convert from display coords to figure-relative coords
-                bbox_fig = inv_transform.transform(title_bbox)
-                max_title_top = max(max_title_top, bbox_fig[1][1])
-            else:  # No title, check for other elements
-                if ax.xaxis.label.get_text():
-                    title_obj = ax.xaxis.label
-                elif ax.yaxis.label.get_text():
-                    title_obj = ax.yaxis.label
-                else:
-                    labels = ax.get_xticklabels()
-                    if labels:
-                        ticklabel_bbox = labels[0].get_window_extent(renderer)
-                        ticklabel_fig_coords = inv_transform.transform(ticklabel_bbox)
-                        max_title_top = max(max_title_top, ticklabel_fig_coords[1, 1])
+        fig_height = self.fig.get_size_inches()[1]
 
-                # If we found a title-like object, handle its bbox
-                if "title_obj" in locals():
-                    title_bbox = title_obj.get_window_extent(renderer)
-                    bbox_fig = inv_transform.transform(title_bbox)
-                    max_title_top = max(max_title_top, bbox_fig[1][1])
-                    # Clean up any previous title_obj variable that was used
-                    del title_obj
-                else:
-                    # Fallback to checking the axis position
-                    max_title_top = max(max_title_top, ax.get_position().ymax)
+        # Get the default title font size (or use a reasonable default)
+        try:
+            # Try to get font size from the first subplot's title
+            first_ax = self.fig.axes[0]
+            if first_ax.get_title():
+                title_fontsize = first_ax.title.get_fontsize()
+            else:
+                title_fontsize = 12
+        except AttributeError:
+            title_fontsize = 12
 
-        # Set the suptitle just above the highest title
-        # Adjust the offset as needed
-        return max_title_top + 0.05
+        # Convert font size to figure-relative units
+        title_height_fig = (title_fontsize / 72.0) / fig_height
+
+        # Add some padding above the title
+        title_padding = 0.15  # 15% of figure height
+
+        suptitle_y = max_ax_top + title_height_fig + title_padding
+
+        return suptitle_y
 
     def format_string(self, string, unique=True, grouped=True):
         if not grouped:

--- a/src/earthkit/plots/components/figures.py
+++ b/src/earthkit/plots/components/figures.py
@@ -593,9 +593,8 @@ class Figure:
                 title_fontsize = first_ax.title.get_fontsize()
             else:
                 title_fontsize = default_title_fontsize
-        except (IndexError, TypeError):
+        except IndexError:
             # IndexError: self.fig.axes is empty
-            # TypeError: self.fig.axes[0] is not a valid Axes object
             # NOTE: We are unlikely to get here, but it's good to be defensive.
             title_fontsize = default_title_fontsize
 


### PR DESCRIPTION
### Description

Fixes a bug that caused contour lines to render very badly whenever a super title was added to a plot.

Before:
<img width="695" height="754" alt="image" src="https://github.com/user-attachments/assets/8c87ecec-ec7c-44fe-97cf-1455d115a73d" />

After:
<img width="699" height="757" alt="image" src="https://github.com/user-attachments/assets/7ef3626d-a49a-4f67-8a48-7af849035af1" />

The issue was that we were drawing the axes multiple times in order to calculate the perfect location for super titles, which breaks the way contour lines are rendered.

The solution was to use a different technique, which is slightly less accurate (as we have to estimate figure and axes sizes rather than access them directly), but which does not require redrawing of the axes.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 