### PR TITLE
Bugfix/healpy optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,9 @@ license = {text = "Apache License Version 2.0"}
 name = "earthkit-plots"
 readme = "README.md"
 requires-python = ">=3.8"
+optional-dependencies.healpy = [
+  "healpy"
+]
 optional-dependencies.test = [
   "nbconvert",
   "nbformat",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ license = {text = "Apache License Version 2.0"}
 name = "earthkit-plots"
 readme = "README.md"
 requires-python = ">=3.8"
-optional-dependencies.healpy = [
+optional-dependencies.healpix = [
   "healpy"
 ]
 optional-dependencies.test = [

--- a/src/earthkit/plots/geo/healpix.py
+++ b/src/earthkit/plots/geo/healpix.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import cartopy.crs as ccrs
-import healpy as hp
 import numpy as np
 
 
@@ -25,6 +24,12 @@ def nnshow(var, nx=1000, ny=1000, ax=None, nest=False, style=None, **kwargs):
     ax: axis to plot on
     kwargs: additional arguments to imshow
     """
+    try:
+        import healpy as hp  # noqa: F401
+    except ImportError as e:
+        raise ImportError(
+            "The healpix plotting backend requires the healpy package."
+        ) from e
     kwargs.pop("transform_first", None)
     xlims = ax.get_xlim()
     ylims = ax.get_ylim()


### PR DESCRIPTION
### Description
Make healpy an optional dependency of earthkit-plots, and raise a suitable error if a user tries to plot HEALPix pixels without it.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 