### PR TITLE
feat: Expand Lat/Lon Identifiers for ORAS5

### DIFF
--- a/src/earthkit/plots/identifiers.py
+++ b/src/earthkit/plots/identifiers.py
@@ -69,12 +69,14 @@ UV_PAIRS = list(zip(U, V))
 LATITUDE = [
     "latitude",
     "lat",
+    "nav_lat",
 ]
 
 LONGITUDE = [
     "longitude",
     "long",
     "lon",
+    "nav_lon",
 ]
 
 TIME = [


### PR DESCRIPTION
Expand Lat/Lon Identifiers for ORAS5

Mitigates issues as seen in #109

>I actually found that the issue is a lot simpler than I first reported - you can get it to work by simply specifying x and y, so it's not an issue with displaying the data but just with recognising which coordinates to use by default! Much much simpler.

Example:

```python
# Plot with eartkit-plots
fig = ekp.Figure(1, 1, size=(5, 5))
subplot = fig.add_map(domain="global")
subplot.grid_cells(data_ORAS5, x="nav_lon", y="nav_lat", z="sosstsst")
```

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 