### PR TITLE
Hotfix: combine_vectors=False by default to fix quickplots

### DIFF
--- a/docs/release-notes/version-0.4-updates.rst
+++ b/docs/release-notes/version-0.4-updates.rst
@@ -1,6 +1,15 @@
 Version 0.4 Updates
 /////////////////////////
 
+Version 0.4.1
+===============
+
+Bug fixes
+++++++++++++++++++
+
+ - Made the default behaviour of quickplot to **not** combine vector components by default. This is to avoid unforeseen
+   issues with some data sources. This will be addressed in release 0.6.
+
 Version 0.4.0
 ===============
 

--- a/src/earthkit/plots/quickplot.py
+++ b/src/earthkit/plots/quickplot.py
@@ -36,7 +36,7 @@ def quickplot(
     groupby=None,
     units=None,
     subplot_titles=None,
-    combine_vectors=True,
+    combine_vectors=False,
     **kwargs,
 ):
     """
@@ -63,6 +63,7 @@ def quickplot(
         Units to convert the data to.
     combine_vectors : bool, optional
         Whether to combine vector components (u, v), and use vector based plotting, i.e. `quiver`.
+        NOTE: This is experimental and seems to have issues with some data sources. This will be addressed in release 0.6.
     **kwargs : dict
         Additional arguments for the plot method(s).
 


### PR DESCRIPTION
### Description
The combine_vectors=True argument caused an unexpected matadata lookup somewhere in earthkit-data, which fails. This makes the default False while we investigate to find a better solution.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 