### PR TITLE
Makes it possible to pass a contour style with a single level

### DIFF
--- a/src/earthkit/plots/styles/__init__.py
+++ b/src/earthkit/plots/styles/__init__.py
@@ -1068,17 +1068,20 @@ class Contour(Style):
         """
         levels = self.levels(data)
 
-        cmap, norm = styles.colors.cmap_and_norm(
-            self._linecolors,
-            levels,
-            self.normalize,
-            self.extend,
-        )
+        if len(levels) > 1:
+            cmap, norm = styles.colors.cmap_and_norm(
+                self._linecolors,
+                levels,
+                self.normalize,
+                self.extend,
+            )
 
-        return {
-            **{"cmap": cmap, "norm": norm, "levels": levels},
-            **self._kwargs,
-        }
+            return {
+                **{"cmap": cmap, "norm": norm, "levels": levels},
+                **self._kwargs,
+            }
+        else:
+            return {"levels": levels, "colors": self._linecolors, **self._kwargs}
 
     def contourf(self, ax, x, y, values, *args, **kwargs):
         """


### PR DESCRIPTION
### Description
Makes it possible to pass a contour style with a single level. For example:
`chart.contour(data, levels=[980])`

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 