### PR TITLE
support specifying z in 1d xarrays

### DIFF
--- a/src/earthkit/plots/sources/xarray.py
+++ b/src/earthkit/plots/sources/xarray.py
@@ -200,13 +200,19 @@ class XarraySource(SingleSource):
         """Handle explicit x, y arguments for 1D data."""
         data_dims = list(self._data.dims)
 
-        # Case 1: Both x and y are provided
-        if self._x is not None and self._y is not None:
+        # Case 1: x,y and z are all provided
+        if self._x is not None and self._y is not None and self._z is not None:
+            x_values = self._get_coordinate_or_variable_values(self._x)
+            y_values = self._get_coordinate_or_variable_values(self._y)
+            z_values = self._get_coordinate_or_variable_values(self._z)
+
+        # Case 2: Both x and y are provided
+        elif self._x is not None and self._y is not None:
             x_values = self._get_coordinate_or_variable_values(self._x)
             y_values = self._get_coordinate_or_variable_values(self._y)
             z_values = None
 
-        # Case 2: Only x is provided
+        # Case 3: Only x is provided (and possibly z, which is ignored)
         elif self._x is not None:
             x_values = self._get_coordinate_or_variable_values(self._x)
             if self._x in data_dims:
@@ -231,7 +237,7 @@ class XarraySource(SingleSource):
             if y_name is not None:
                 self._y = y_name
 
-        # Case 3: Only y is provided
+        # Case 4: Only y is provided (and possibly z, which is ignored)
         elif self._y is not None:
             y_values = self._get_coordinate_or_variable_values(self._y)
             if self._y in data_dims:
@@ -256,7 +262,7 @@ class XarraySource(SingleSource):
             if x_name is not None:
                 self._x = x_name
 
-        # Case 4: Only z is provided (unusual for 1D, but handle gracefully)
+        # Case 5: Only z is provided (unusual for 1D, but handle gracefully)
         elif self._z is not None:
             z_values = self._get_coordinate_or_variable_values(self._z)
             # For 1D data, if only z is provided, we need to infer x and y

--- a/tests/sources/test_xarray.py
+++ b/tests/sources/test_xarray.py
@@ -251,6 +251,22 @@ def test_xarray_source_1d_explicit_both():
     assert np.array_equal(source.y_values, np.array([10, 20, 30]))
     assert source.z_values is None
 
+def test_xarray_source_1d_explicit_all():
+    """Test XarraySource with 1D data and explicit x, y and z coordinates."""
+    data = xr.DataArray(
+        np.array([10, 20, 30]),
+        dims=["bananas"],
+        coords={
+            "bananas": [0, 1, 2],
+            "apples": ("bananas", [4,5,6]),
+        },
+        name="onions",
+    )
+    source = XarraySource(data, x="bananas", y="onions", z="apples")
+    assert np.array_equal(source.x_values, np.array([0, 1, 2]))
+    assert np.array_equal(source.y_values, np.array([10, 20, 30]))
+    assert np.array_equal(source.z_values, np.array([4,5,6]))
+
 
 def test_xarray_source_explicit_2d_all_coords():
     """Test XarraySource with 2D data and all coordinates explicitly specified."""


### PR DESCRIPTION
### Description
Allow specifying also `z` coords for a 1d xarray source, for use in scatter plots or similar.

Currently we have
```python
>> xr_source = XarraySource(ds, x="x", y="y", z="z")
>> print("x", xr_source.x_values)
>> print("y", xr_source.y_values)
>> print("z", xr_source.z_values)
x [0, 1]
y [1, 2]
z None
```
This PR proposes changing that to
```python
x [0, 1]
y [1, 2]
z [2, 3]
```


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 