### PR TITLE
Fixes issue with automatic plotting of polytope data as point clouds

### DIFF
--- a/src/earthkit/plots/sources/xarray.py
+++ b/src/earthkit/plots/sources/xarray.py
@@ -53,6 +53,12 @@ class XarraySource(SingleSource):
     def __init__(self, dataarray, x=None, y=None, z=None, **kwargs):
         dataarray = dataarray.squeeze()
         self._xarray_source = dataarray
+
+        # Track whether x, y, z were explicitly provided by the user
+        self._explicit_x = x is not None
+        self._explicit_y = y is not None
+        self._explicit_z = z is not None
+
         if isinstance(dataarray, xr.Dataset):
             if z is not None:
                 dataarray = dataarray[z]
@@ -103,7 +109,8 @@ class XarraySource(SingleSource):
 
     def _infer_xyz(self):
         """Infers x, y, and z values based on xarray input dimensions and provided names."""
-        if self._x is not None or self._y is not None or self._z is not None:
+        # Only use explicit path if user actually provided x, y, or z
+        if self._explicit_x or self._explicit_y or self._explicit_z:
             return self._explicit_xyz()
         else:
             return self._implicit_xyz()
@@ -124,9 +131,39 @@ class XarraySource(SingleSource):
             self._z = None
             return x_values, y_values, z_values
 
-        # Case 2: 1D data with one dimension (e.g., time series)
+        # Case 2: 1D data with one dimension (e.g., time series or point data)
         elif len(data_shape) == 1 and len(data_dims) == 1:
             dim_name = data_dims[0]
+
+            # Check if there are x and y coordinates in the coords (e.g., latitude/longitude for point data)
+            coord_names = list(self._data.coords.keys())
+            x_coord = find_x(coord_names)
+            y_coord = find_y(coord_names)
+
+            # If we found both x and y coordinates (and they're not the dimension itself),
+            # check if they have the same shape as the data (point data case)
+            if x_coord and y_coord and x_coord != dim_name and y_coord != dim_name:
+                x_coord_data = self._data.coords[x_coord]
+                y_coord_data = self._data.coords[y_coord]
+
+                # Check if the coordinates have the same shape as the data variable
+                # This distinguishes point data from scalar location metadata
+                if (
+                    hasattr(x_coord_data, "shape")
+                    and hasattr(y_coord_data, "shape")
+                    and x_coord_data.shape == data_shape
+                    and y_coord_data.shape == data_shape
+                ):
+                    # Point data case: use coordinates for x/y and data values for z
+                    x_values = x_coord_data.values
+                    y_values = y_coord_data.values
+                    z_values = self._data.values
+                    self._x = x_coord
+                    self._y = y_coord
+                    self._z = self._data.name if hasattr(self._data, "name") else None
+                    return x_values, y_values, z_values
+
+            # Otherwise, treat as time series or simple 1D data
             # The dimension's values become x_values, variable values become y_values
             x_values = self._data[dim_name].values
             y_values = self._data.values

--- a/tests/sources/test_xarray.py
+++ b/tests/sources/test_xarray.py
@@ -556,3 +556,58 @@ def test_xarray_dataset_no_coordinate_variables():
         ValueError, match="Multiple variables found in the xarray Dataset"
     ):
         XarraySource(data)
+
+
+def test_xarray_source_1d_point_data_with_lat_lon():
+    """Test XarraySource with 1D point data that has latitude and longitude coordinates."""
+    # Example: temperature measurements at different lat/lon points
+    data = xr.DataArray(
+        np.array([20, 25, 30, 22]),
+        dims=["point"],
+        coords={
+            "point": [0, 1, 2, 3],
+            "latitude": ("point", [10.0, 20.0, 30.0, 40.0]),
+            "longitude": ("point", [5.0, 15.0, 25.0, 35.0]),
+        },
+        name="temperature",
+    )
+
+    source = XarraySource(data)
+
+    # Should detect longitude as x, latitude as y, and temperature as z
+    assert np.array_equal(source.x_values, np.array([5.0, 15.0, 25.0, 35.0]))
+    assert np.array_equal(source.y_values, np.array([10.0, 20.0, 30.0, 40.0]))
+    assert np.array_equal(source.z_values, np.array([20, 25, 30, 22]))
+    assert source._x == "longitude"
+    assert source._y == "latitude"
+    assert source._z == "temperature"
+
+
+def test_xarray_source_1d_time_series_with_scalar_lat_lon():
+    """Test XarraySource with 1D time series data that has scalar latitude/longitude metadata."""
+    # Example: temperature time series at a single location (lat/lon are scalars)
+    import pandas as pd
+
+    times = pd.date_range("2025-08-20", "2025-08-23T23:00:00", freq="h")
+
+    data = xr.DataArray(
+        np.random.randn(96),
+        dims=["valid_time"],
+        coords={
+            "valid_time": times,
+            "latitude": 45.0,  # Scalar latitude
+            "longitude": -120.0,  # Scalar longitude
+        },
+        name="t2m",
+    )
+
+    source = XarraySource(data)
+
+    # Should treat as time series: x=valid_time, y=t2m values, z=None
+    # Should NOT use the scalar lat/lon as x/y
+    assert len(source.x_values) == 96
+    assert len(source.y_values) == 96
+    assert source.z_values is None
+    assert source._x == "valid_time"
+    assert source._y == "t2m"
+    assert source._z is None


### PR DESCRIPTION
### Description
Fixes automatic identification of x, y and z from 1D data in xarray. The new logic is as follows:

- Do we have an identifiable x, y **and** z?
  - Yes → are they all the same shape?
    - Yes → these are x, y and z
    - No → if there is another dimension/coordinate that matches the length of z, make that dimension/coordinate x and make z become y

This may require a more robust solution in the future - perhaps a solution where the x, y and z values are extracted based on the plot type, which should provide enough context to do this more safely.
### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 