### PR TITLE
Add Denmark and Ireland to domains.yml

### DIFF
--- a/src/earthkit/plots/data/geo/domains.yml
+++ b/src/earthkit/plots/data/geo/domains.yml
@@ -22,6 +22,9 @@ domains:
   southeast Europe: [15, 40, 34, 45]
   Southwest Europe: [-25, 15, 34, 45]
   Mediterranean: [-8, 36, 28, 44]
+ 
+  Denmark: [7, 16, 54, 58]
+  Ireland: [-11, -5, 51, 56]
 
   Svalbard: [9, 33, 76, 81]
 


### PR DESCRIPTION
### Description

This PR simply adds a proper domain for Denmark (see issue https://github.com/ecmwf/earthkit-plots/issues/148) and Ireland.

With this the domain "Ireland" and "Denmark" looks like the following:

<img width="530" height="705" alt="Screenshot 2025-12-03 at 14 14 13" src="https://github.com/user-attachments/assets/ff4d26bb-fd8f-4eb1-ab3a-24e509becd3f" />

<img width="799" height="619" alt="Screenshot 2025-12-03 at 14 14 56" src="https://github.com/user-attachments/assets/5f872847-a4b6-4f03-8e9f-03246bac3764" />

```python
import earthkit.plots as ekp
chart = ekp.Map(domain="Ireland")
chart.coastlines(resolution="10m", color="black", linewidth=0.6, alpha=0.5)
chart.show()
```


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 