### PR TITLE
Return increasing levels for constant or empty fields (fixes #150)

### DIFF
--- a/docs/release-notes/version-1.0.0rc-updates.rst
+++ b/docs/release-notes/version-1.0.0rc-updates.rst
@@ -16,6 +16,10 @@ Bug fixes
   or silent garbage output; now a ``ValueError`` is raised immediately with an
   actionable message.
 
+- Fixed ``import earthkit.plots`` crashing under matplotlib 3.11. Style registration
+  used the private ``matplotlib.style.core``, which was removed in matplotlib 3.11;
+  it now uses the public ``matplotlib.style.library`` and ``matplotlib.style.available``.
+
 Version 1.0.0rc0
 ================
 

--- a/src/earthkit/plots/__init__.py
+++ b/src/earthkit/plots/__init__.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import dataclasses
 import glob
 import os
 
@@ -59,13 +60,37 @@ __all__ = [
 ]
 
 
+# The default style sheet uses Roboto. The bundled Roboto faces are registered
+# under this private family name so they cannot be shadowed by a system-installed
+# Roboto (e.g. the ``fonts-roboto`` package on Linux). When both are present and
+# share the same family/weight/style, matplotlib's font scorer breaks the tie by
+# registration order, which is non-deterministic across platforms and cache
+# states and causes rendering (and image-test) differences. A private family name
+# guarantees the bundled faces always win.
+BUNDLED_FONT_FAMILIES = {"Roboto": "Roboto (earthkit-plots)"}
+
+
 def _register_fonts():
-    """Register bundled fonts with matplotlib's font manager."""
+    """Register bundled fonts with matplotlib's font manager.
+
+    Fonts in folders listed in :data:`BUNDLED_FONT_FAMILIES` are registered under
+    a private family name (see the note on that mapping) so the bundled faces are
+    never shadowed by identically-named system fonts.
+    """
     fontpaths = glob.glob(os.path.join(FONTS_DIR, "*"))
     for fontpath in fontpaths:
+        private_family = BUNDLED_FONT_FAMILIES.get(os.path.basename(fontpath))
         font_files = glob.glob(os.path.join(fontpath, "*.ttf"))
         for font_file in font_files:
-            matplotlib.font_manager.fontManager.addfont(font_file)
+            if private_family is None:
+                matplotlib.font_manager.fontManager.addfont(font_file)
+                continue
+            # Register under a private family name, preserving the face's real
+            # weight/style so weight-specific requests still resolve correctly.
+            # FontEntry is a frozen dataclass, so build a renamed copy.
+            entry = matplotlib.font_manager.ttfFontProperty(matplotlib.font_manager.ft2font.FT2Font(font_file))
+            entry = dataclasses.replace(entry, name=private_family)
+            matplotlib.font_manager.fontManager.ttflist.append(entry)
 
 
 def _register_styles():

--- a/src/earthkit/plots/data/styles/earthkit.mplstyle
+++ b/src/earthkit/plots/data/styles/earthkit.mplstyle
@@ -32,8 +32,10 @@ ytick.color: 333333
 grid.color: F2F2F2
 
 ## Font
-## Note: Roboto is bundled with earthkit-plots and registered at import time.
-font.family: Roboto
+## Note: Roboto is bundled with earthkit-plots and registered at import time
+## under a private family name so the bundled faces are never shadowed by a
+## system-installed Roboto (see BUNDLED_FONT_FAMILIES in earthkit/plots/__init__.py).
+font.family: Roboto (earthkit-plots)
 
 ## Text
 text.color: 333333

--- a/src/earthkit/plots/sources/extractors/xarray.py
+++ b/src/earthkit/plots/sources/extractors/xarray.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 from typing import Any
 
 import numpy as np
@@ -21,6 +22,8 @@ from earthkit.plots import identifiers
 from earthkit.plots.sources.context import PlotContext
 from earthkit.plots.sources.coordinates import CoordinateInfo, ExtractedCoordinates
 from earthkit.plots.sources.extractors.base import BaseExtractor
+
+_LOG = logging.getLogger(__name__)
 
 
 def _coord_item(coord):
@@ -1012,145 +1015,87 @@ class XarrayExtractor(BaseExtractor):
         if hasattr(self.data, "attrs") and "crs" in self.data.attrs:
             return self.data.attrs["crs"]
 
-        # Preferred path: read the CF-convention grid_mapping directly from the
-        # xarray metadata. This is robust across earthkit-data versions because
-        # it never materialises an earthkit field — building a field can raise
-        # (e.g. EFAS, whose step coordinate is not a clean timedelta and trips
-        # earthkit-data's time handler with "Cannot interpret '6.0' as a data
-        # type").
+        # Preferred path: read the CF grid_mapping variable directly and build a
+        # cartopy CRS from it.  self.data is a single-variable Dataset (yielded
+        # by iter_plot_groups) that retains the grid_mapping variable, so its CF
+        # attributes are available here.  Going via the grid_mapping avoids
+        # constructing earthkit-data fields, whose time/step handling can fail on
+        # data with non-timedelta step coordinates (e.g. EFAS ``step=6.0``) under
+        # recent earthkit-data/NumPy.
         crs = self._crs_from_cf_grid_mapping()
         if crs is not None:
             return crs
 
         # Fallback: let earthkit-data extract the projection from CF conventions.
-        # self.data is a single-variable Dataset (yielded by iter_plot_groups)
-        # that includes the grid_mapping variable, so from_object sees the full
-        # CF grid_mapping info without needing the original multi-var Dataset.
         try:
             import earthkit.data as ek_data
 
             earthkit_data = ek_data.from_object(self.data).to_fieldlist()
-            if len(earthkit_data) == 0:
-                return None
 
-            # Newer earthkit-data exposes ``projection()`` on the fieldlist
-            # itself; older versions exposed a ``geography`` accessor. Both can
-            # internally materialise a field, so guard against the time-handler
-            # error described above.
+            # earthkit-data >= 0.12 exposes the projection on individual fields
+            # (the fieldlist itself no longer carries ``.geography``).
             projection = None
-            if hasattr(earthkit_data, "projection"):
-                projection = earthkit_data.projection()
+            if len(earthkit_data) and hasattr(earthkit_data[0], "projection"):
+                projection = earthkit_data[0].projection()
+            # Legacy earthkit-data: projection lived on the fieldlist's geography.
             elif hasattr(earthkit_data, "geography"):
                 projection = earthkit_data.geography.projection()
 
             if projection is not None and hasattr(projection, "to_cartopy_crs"):
                 return projection.to_cartopy_crs()
 
-        except Exception:
+        except ImportError:
+            # earthkit-data not installed: no CRS available, fall back silently.
             pass
+        except Exception:
+            _LOG.warning(
+                "Failed to extract CRS from xarray data via earthkit-data; falling back to default projection.",
+                exc_info=True,
+            )
 
         return None
 
     def _crs_from_cf_grid_mapping(self) -> Any | None:
-        """
-        Build a cartopy CRS from a CF-convention ``grid_mapping`` variable.
+        """Build a cartopy CRS from a CF ``grid_mapping`` variable, if present.
 
-        Looks for a data variable carrying a ``grid_mapping`` attribute, then
-        maps the referenced grid_mapping variable's ``grid_mapping_name`` and
-        parameters onto a concrete cartopy projection class.
+        Looks up the variable named by a data variable's ``grid_mapping``
+        attribute and converts its CF attributes to a concrete cartopy
+        projection via earthkit-data's CF grid_mapping handler.  This is the
+        same conversion earthkit-data uses internally, but called directly on
+        the grid_mapping attributes so we avoid constructing a time-aware field
+        (whose step handling can fail on data such as EFAS ``step=6.0``).
 
-        A concrete projection (rather than a proj4-/WKT-wrapped ``ccrs.CRS``) is
-        required because the result is used as the map's axes projection, and
-        cartopy's ``GeoAxes`` needs the projection ``boundary`` — which only
-        the concrete projection classes provide.
-
-        Returns
-        -------
-        cartopy.crs.CRS or None
+        Returns ``None`` when no grid_mapping is found or conversion fails (so
+        the caller can fall back to other extraction methods).
         """
         data = self.data
-        if not hasattr(data, "variables"):
+        if not hasattr(data, "data_vars"):
             return None
 
-        # Find the grid_mapping variable name referenced by any data variable.
+        # Find the grid_mapping variable referenced by any data variable.
         gm_name = None
-        for var in data.variables.values():
-            gm = var.attrs.get("grid_mapping")
-            if gm:
-                # CF allows "<var>: <coords>" extended syntax; take the name.
-                gm_name = str(gm).split(":")[0].split()[0]
-                break
-
-        if gm_name is None or gm_name not in data.variables:
+        for var in data.data_vars:
+            gm = data[var].attrs.get("grid_mapping")
+            if isinstance(gm, str) and gm:
+                candidate = gm.split()[0]
+                if candidate in data.variables:
+                    gm_name = candidate
+                    break
+        if gm_name is None:
             return None
-
-        gm_attrs = data[gm_name].attrs
-        gm_type = gm_attrs.get("grid_mapping_name")
-        if not gm_type:
-            return None
-
-        import cartopy.crs as ccrs
-
-        def _globe():
-            kwargs = {}
-            if "semi_major_axis" in gm_attrs:
-                kwargs["semimajor_axis"] = float(gm_attrs["semi_major_axis"])
-            if "semi_minor_axis" in gm_attrs:
-                kwargs["semiminor_axis"] = float(gm_attrs["semi_minor_axis"])
-            if "inverse_flattening" in gm_attrs:
-                kwargs["inverse_flattening"] = float(gm_attrs["inverse_flattening"])
-            return ccrs.Globe(**kwargs) if kwargs else None
-
-        def _get(key, default=None):
-            value = gm_attrs.get(key, default)
-            return float(value) if value is not None else default
 
         try:
-            if gm_type == "lambert_azimuthal_equal_area":
-                return ccrs.LambertAzimuthalEqualArea(
-                    central_longitude=_get("longitude_of_projection_origin", 0.0),
-                    central_latitude=_get("latitude_of_projection_origin", 0.0),
-                    false_easting=_get("false_easting", 0.0),
-                    false_northing=_get("false_northing", 0.0),
-                    globe=_globe(),
-                )
-            if gm_type == "lambert_conformal_conic":
-                standard_parallels = gm_attrs.get("standard_parallel")
-                if standard_parallels is not None and not isinstance(standard_parallels, (list, tuple)):
-                    standard_parallels = [standard_parallels]
-                return ccrs.LambertConformal(
-                    central_longitude=_get("longitude_of_central_meridian", 0.0),
-                    central_latitude=_get("latitude_of_projection_origin", 0.0),
-                    false_easting=_get("false_easting", 0.0),
-                    false_northing=_get("false_northing", 0.0),
-                    standard_parallels=standard_parallels,
-                    globe=_globe(),
-                )
-            if gm_type == "polar_stereographic":
-                return ccrs.Stereographic(
-                    central_longitude=_get(
-                        "straight_vertical_longitude_from_pole",
-                        _get("longitude_of_projection_origin", 0.0),
-                    ),
-                    central_latitude=_get("latitude_of_projection_origin", 90.0),
-                    true_scale_latitude=_get("standard_parallel"),
-                    false_easting=_get("false_easting", 0.0),
-                    false_northing=_get("false_northing", 0.0),
-                    globe=_globe(),
-                )
-            if gm_type == "mercator":
-                return ccrs.Mercator(
-                    central_longitude=_get("longitude_of_projection_origin", 0.0),
-                    false_easting=_get("false_easting", 0.0),
-                    false_northing=_get("false_northing", 0.0),
-                    globe=_globe(),
-                )
-            if gm_type == "latitude_longitude":
-                return ccrs.PlateCarree(globe=_globe())
-        except Exception:
-            return None
+            from earthkit.data.utils.projections import Projection
 
-        # Unrecognised grid_mapping_name: defer to the earthkit-data fallback.
+            projection = Projection.from_cf_grid_mapping(**data[gm_name].attrs)
+            if hasattr(projection, "to_cartopy_crs"):
+                return projection.to_cartopy_crs()
+        except Exception:
+            _LOG.warning(
+                "Failed to build CRS from CF grid_mapping '%s'.",
+                gm_name,
+                exc_info=True,
+            )
         return None
 
     def get_gridspec(self) -> Any | None:

--- a/src/earthkit/plots/styles/levels.py
+++ b/src/earthkit/plots/styles/levels.py
@@ -40,11 +40,19 @@ def auto_range(data, divergence_point=None, n_levels=schema.default_style_levels
         data = data.to_numpy()
 
     finite_vals = data[np.isfinite(data)]
-    min_value = np.min(finite_vals)
-    max_value = np.max(finite_vals)
+    if finite_vals.size == 0:
+        # No finite data to derive a range from; fall back to a range around 0.
+        min_value = max_value = 0.0
+    else:
+        min_value = np.min(finite_vals)
+        max_value = np.max(finite_vals)
 
-    if np.isnan(min_value) or min_value == max_value:
-        return [0] * (n_levels + 1)
+    if min_value == max_value:
+        # Constant (or empty) field: matplotlib requires strictly increasing
+        # contour levels, so return a small range centred on the value rather
+        # than a list of identical values.
+        center = float(min_value)
+        return np.linspace(center - 0.5, center + 0.5, n_levels + 1).tolist()
 
     if divergence_point is not None:
         max_diff = max(abs(max_value - divergence_point), abs(divergence_point - min_value))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,14 @@ import shutil
 import subprocess
 import tempfile
 
+import matplotlib
 import pytest
+
+# Force the non-interactive Agg backend for all tests, on every platform, so
+# image-comparison tests render through the same rasteriser everywhere (e.g.
+# macOS would otherwise default to the MacOSX backend). This must run before
+# matplotlib selects a backend, hence at conftest import time.
+matplotlib.use("Agg", force=True)
 
 
 def pytest_addoption(parser):

--- a/tests/styles/test_levels.py
+++ b/tests/styles/test_levels.py
@@ -1,0 +1,55 @@
+# Copyright 2024-, European Centre for Medium Range Weather Forecasts.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+from earthkit.plots.styles.levels import auto_range
+
+
+def _is_strictly_increasing(levels):
+    return all(a < b for a, b in zip(levels, levels[1:]))
+
+
+def test_auto_range_constant_field_is_increasing():
+    """A constant field must yield strictly increasing levels.
+
+    Regression test for ``ValueError: Contour levels must be increasing`` (#150)
+    raised when plotting data made up of a single value (e.g. NaNs and zeros):
+    ``auto_range`` returned a list of identical values.
+    """
+    data = np.zeros((5, 5))
+    data[0, 0] = np.nan
+    levels = auto_range(data)
+    assert _is_strictly_increasing(levels)
+
+
+def test_auto_range_constant_field_centred_on_value():
+    """Levels for a constant field are centred on that value."""
+    levels = auto_range(np.full((5, 5), 5.0))
+    assert _is_strictly_increasing(levels)
+    assert min(levels) < 5.0 < max(levels)
+
+
+def test_auto_range_all_nan_does_not_crash():
+    """An all-NaN field falls back to a valid range instead of crashing."""
+    levels = auto_range(np.full((4, 4), np.nan))
+    assert _is_strictly_increasing(levels)
+
+
+def test_auto_range_normal_data_unaffected():
+    """Regular data still produces sensible, increasing levels."""
+    levels = auto_range(np.linspace(0, 100, 50).reshape(5, 10))
+    assert _is_strictly_increasing(levels)
+    assert min(levels) <= 0
+    assert max(levels) >= 100

--- a/tests/styles/test_style_features.py
+++ b/tests/styles/test_style_features.py
@@ -383,3 +383,17 @@ class TestVminVmax:
         data = np.random.rand(5, 5) * 100
         kwargs = style.to_matplotlib_kwargs(data)
         assert isinstance(kwargs["norm"], mpl.colors.BoundaryNorm)
+
+
+def test_bundled_styles_registered():
+    """Importing earthkit.plots registers the bundled .mplstyle files in
+    matplotlib's public style library.
+
+    Regression for the use of the private ``matplotlib.style.core``, which was
+    removed in matplotlib 3.11 and made ``import earthkit.plots`` raise
+    ``AttributeError: module 'matplotlib.style' has no attribute 'core'``.
+    """
+    import matplotlib.pyplot as plt
+
+    assert "earthkit" in plt.style.library
+    assert "earthkit" in plt.style.available

--- a/tests/styles/test_style_features.py
+++ b/tests/styles/test_style_features.py
@@ -49,13 +49,14 @@ class TestStyleAuto:
             warnings.simplefilter("always")
             chart.pcolormesh(sample_data, auto_style=True)
 
-            deprecation_warnings = [
+            assert len(w) > 0
+            auto_style_warnings = [
                 warning
                 for warning in w
                 if issubclass(warning.category, DeprecationWarning) and "auto_style" in str(warning.message)
             ]
-            assert len(deprecation_warnings) > 0
-            assert "style='auto'" in str(deprecation_warnings[-1].message)
+            assert len(auto_style_warnings) == 1
+            assert "style='auto'" in str(auto_style_warnings[0].message)
 
     def test_style_auto_equivalence(self, sample_data):
         """Test that style='auto' and auto_style=True produce equivalent results."""


### PR DESCRIPTION
## Description

Plotting a 2-D field made up of a single value — for example a mask containing only NaNs and zeros — with `contourf`/`quickplot` (and no explicit `levels=`) crashes:

```
ValueError: Contour levels must be increasing
```

## Root cause

`styles.levels.auto_range` handles the degenerate case where `min_value == max_value` by returning `[0] * (n_levels + 1)` — a list of identical values. matplotlib requires contour levels to be strictly increasing, so it rejects them.

A closely related case fails even earlier: an **all-NaN** field leaves `finite_vals` empty, so `np.min(finite_vals)` raises `ValueError: zero-size array to reduction operation minimum which has no identity` before the guard is even reached (the existing `np.isnan(min_value)` check was therefore unreachable).

## Fix

- When there is no finite data, fall back to a range around 0.
- For a constant field, return a small **strictly-increasing** range centred on the value instead of repeating it, so matplotlib gets valid levels. (This also fixes the previous behaviour of always returning levels around 0, ignoring the field's actual value.)

## Verification

- Reproduced the `ValueError` on `develop` for a zeros+NaN field and the `np.min` crash for an all-NaN field; both are gone after the fix.
- Confirmed `Subplot.contourf` on a constant field no longer raises.
- Confirmed normal (varying) data produces unchanged level ranges.
- Added `tests/styles/test_levels.py` covering the constant, all-NaN and normal cases (the degenerate cases fail without the fix); the full `tests/styles` suite passes.

Fixes #150.