### PR TITLE
Fix import crash under matplotlib 3.11 (style.core removed)

### DIFF
--- a/docs/release-notes/version-1.0.0rc-updates.rst
+++ b/docs/release-notes/version-1.0.0rc-updates.rst
@@ -16,6 +16,10 @@ Bug fixes
   or silent garbage output; now a ``ValueError`` is raised immediately with an
   actionable message.
 
+- Fixed ``import earthkit.plots`` crashing under matplotlib 3.11. Style registration
+  used the private ``matplotlib.style.core``, which was removed in matplotlib 3.11;
+  it now uses the public ``matplotlib.style.library`` and ``matplotlib.style.available``.
+
 Version 1.0.0rc0
 ================
 

--- a/src/earthkit/plots/__init__.py
+++ b/src/earthkit/plots/__init__.py
@@ -72,8 +72,8 @@ def _register_styles():
     """Register bundled .mplstyle files with matplotlib's style library."""
     for mplstyle in DEFAULT_STYLES_DIR.glob("*.mplstyle"):
         rc = matplotlib.rc_params_from_file(str(mplstyle), use_default_template=False)
-        plt.style.core.library[mplstyle.stem] = rc
-    plt.style.core.available[:] = sorted(plt.style.core.library.keys())
+        plt.style.library[mplstyle.stem] = rc
+    plt.style.available[:] = sorted(plt.style.library.keys())
 
 
 _register_fonts()

--- a/tests/styles/test_style_features.py
+++ b/tests/styles/test_style_features.py
@@ -380,3 +380,17 @@ class TestVminVmax:
         data = np.random.rand(5, 5) * 100
         kwargs = style.to_matplotlib_kwargs(data)
         assert isinstance(kwargs["norm"], mpl.colors.BoundaryNorm)
+
+
+def test_bundled_styles_registered():
+    """Importing earthkit.plots registers the bundled .mplstyle files in
+    matplotlib's public style library.
+
+    Regression for the use of the private ``matplotlib.style.core``, which was
+    removed in matplotlib 3.11 and made ``import earthkit.plots`` raise
+    ``AttributeError: module 'matplotlib.style' has no attribute 'core'``.
+    """
+    import matplotlib.pyplot as plt
+
+    assert "earthkit" in plt.style.library
+    assert "earthkit" in plt.style.available


### PR DESCRIPTION
## Problem

`import earthkit.plots` currently crashes on matplotlib 3.11:

```python
>>> import earthkit.plots
AttributeError: module 'matplotlib.style' has no attribute 'core'
```

`_register_styles()` (`src/earthkit/plots/__init__.py`) registers the bundled `.mplstyle` files through the **private** `matplotlib.style.core` submodule, which was removed in matplotlib 3.11. Because this runs at import time, the whole package fails to import, and on CI **every test errors at collection** (the current `develop` runs are red across all Python versions for this reason — 297 items / 31 collection errors).

## Fix

Use the public `matplotlib.style.library` and `matplotlib.style.available` instead of `matplotlib.style.core.*`. These have long been the supported entry points and refer to the same objects, so the behaviour is unchanged on the older matplotlib versions while also working on 3.11:

```diff
-        plt.style.core.library[mplstyle.stem] = rc
-    plt.style.core.available[:] = sorted(plt.style.core.library.keys())
+        plt.style.library[mplstyle.stem] = rc
+    plt.style.available[:] = sorted(plt.style.library.keys())
```

After the change, `import earthkit.plots` succeeds on matplotlib 3.11 and the bundled `earthkit` style is registered in `matplotlib.pyplot.style.available` as before.

## Tests

Added `test_bundled_styles_registered` in `tests/styles/test_style_features.py`, asserting the bundled style ends up in the public style library. It is RED on the old code (the module errors at collection with the `style.core` `AttributeError`) and GREEN with the fix. With the import restored, the suite now collects all 546 tests and 501 of the non-image tests pass on matplotlib 3.11.

Heads-up: two unrelated matplotlib-3.11 issues remain visible once collection is unblocked and are out of scope here — `test_auto_style_deprecated` (matplotlib now emits a `PendingDeprecationWarning` from `set_bad`, so it is no longer the *last* recorded warning) and an rcParams test-isolation flake (`test_rcparams_restored_after_save` passes in isolation). Happy to follow up on those separately if useful.

Disclosure: I prepared this fix with AI assistance under my direction; I reviewed and verified the change and the test myself.
