### PR TITLE
Reduce land zorder to -1

### DIFF
--- a/src/earthkit/plots/data/styles/schema.yml
+++ b/src/earthkit/plots/data/styles/schema.yml
@@ -229,7 +229,7 @@ roads:
   alpha: 0.5
   facecolor: "none"
 land:
-  zorder: 0
+  zorder: -1
   color: "#e8e8e8"
 urban_areas:
   color: "#d1d1d1"


### PR DESCRIPTION
### Description

Sets the `zorder` parameter for the `Map.land()` layer to `-1` by default, ensuring it is below data and other ancillary layers.

Closes #234.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
