### PR TITLE
Handle ListedColormaps in expand and cmap_and_norm

### DIFF
--- a/src/earthkit/plots/styles/colors/__init__.py
+++ b/src/earthkit/plots/styles/colors/__init__.py
@@ -98,8 +98,9 @@ def cmap_and_norm(colors, levels, normalize=True, extend=None, extend_levels=Tru
 
     Parameters
     ----------
-    colors : str or list
-        The name of a matplotlib colormap or a list of colours.
+    colors : str or list or matplotlib.colors.Colormap
+        The name of a matplotlib colormap, a list of colours, or a matplotlib
+        colormap object (e.g. a ``ListedColormap``).
     levels : list
         The levels for which to generate colours.
     normalize : bool, optional

--- a/src/earthkit/plots/styles/colors/__init__.py
+++ b/src/earthkit/plots/styles/colors/__init__.py
@@ -69,6 +69,8 @@ def expand(colors, levels, extend_colors=0):
             colors = [colors] * (length - 1)
         else:
             colors = [cmap(i) for i in np.linspace(0, 1, length)]
+    elif isinstance(colors, ListedColormap):
+        colors = list(colors.colors)
     elif isinstance(colors, mpl.colors.Colormap):
         colors = [colors(i) for i in np.linspace(0, 1, length)]
     return colors
@@ -108,6 +110,7 @@ def cmap_and_norm(colors, levels, normalize=True, extend=None, extend_levels=Tru
         Whether to extend the levels. If False, the levels will be used as is.
         If True, the levels will be extended to include the under and over values.
     """
+    is_listed = isinstance(colors, ListedColormap)
     levels = list(levels)
     extend_colors = 0
     color_levels = levels
@@ -134,7 +137,6 @@ def cmap_and_norm(colors, levels, normalize=True, extend=None, extend_levels=Tru
     N = len(color_levels) + extend_colors - 1
 
     colormap = LinearSegmentedColormap.from_list
-    is_listed = colors is not None and len(colors) == N
     if is_listed:
         colormap = ListedColormap
 


### PR DESCRIPTION
### Description
Resolves #240 by checking whether `colors` is a `ListedColormap` directly upon entering `cmap_and_norm` rather than after modification (extension). Now works when defining the `Style` as follows, where `levels` represents the right border of each level and there is an additional extension at the end. I'm assuming that's the intended behaviour but not sure.

```python
newstyle = Style(
    colors=ListedColormap(['#ff0100', '#feaa00', '#fffc03', '#ffffff', '#ffffff', '#eaccf8', '#af51c3', '#7a007b']),
    levels=[-2, -1.5, -1, 0, 1, 1.5, 2],
    extend="both",
)

# Plot with custom style:
fig = ekp.Figure(rows=1, columns=1)
subplot = fig.add_map(domain="Spain")
subplot.grid_cells(data, z="SPI1", style=newstyle)
subplot.legend()
fig.coastlines()
fig.show()
```

<img width="706" height="715" alt="download" src="https://github.com/user-attachments/assets/2384f896-ebdf-4b26-8f76-eba351f215ab" />

Testing without `style=` shows no change in the default behaviour (as intended) but I'm not sure what other tests are useful here.

Minimum working example, can probably be improved in terms of e.g. skipping parts of `cmap_and_norm` completely for `ListedColormap`s.

I think it would be good to add this to the documentation [gallery](https://earthkit-plots.readthedocs.io/en/latest/examples/gallery/gallery.html) somewhere but wasn't sure where. If you want to go really crazy you could add SPI and SPEI as built-in styles.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
